### PR TITLE
Addressing timesheet_deleteds bug

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     keywords=['api', 'rest', 'tsheets'],
     install_requires=[
         'requests>=2.7.0',
-        'python-dateutil==2.4.2',
-        'pytz==2015.7'
+        'python-dateutil>=2.4.2',
+        'pytz>=2015.7'
     ]
 )

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     keywords=['api', 'rest', 'tsheets'],
     install_requires=[
         'requests>=2.7.0',
-        'python-dateutil>=2.4.2',
+        'python-dateutil==2.8.1',
         'pytz>=2015.7'
     ]
 )

--- a/tsheets/bridge.py
+++ b/tsheets/bridge.py
@@ -40,7 +40,7 @@ class Bridge(object):
                         s_dict[key] = list(value.values())
                 has_more = data.get('more', None)
                 result = {"items": self.items_from_data(data, name, is_singleton, mode),
-                          "has_more": (has_more == 'true'),
+                          "has_more": (has_more == True),
                           "supplemental": s_dict}
                 return result
         else:

--- a/tsheets/results.py
+++ b/tsheets/results.py
@@ -9,6 +9,8 @@ class Results(object):
         self.repo = repo
         self.model = repo.model
         self.name = class_to_endpoint(self.model.__name__) + ('' if is_singleton else 's')
+        if isinstance(self.repo, repos.TimesheetsDeleted):
+            self.name = 'timesheets_deleted'
         self.index = -1
         self.loaded = []
         self.bridge = bridge


### PR DESCRIPTION
When using the API to query timesheets_deleted, line 11 causes a problem where the query looks for timesheet_deleteds. This special cases for that class, though I'm a python amateur and there may be a cleaner way to do that.